### PR TITLE
Add language name aliases and search language by its alias

### DIFF
--- a/data.js
+++ b/data.js
@@ -124,7 +124,7 @@ module.exports = [
     {"name":"Ossetian", "local":"ирон æвзаг", "1":"os", "2":"oss", "2T":"oss", "2B":"oss", "3":"oss"},
     {"name":"Panjabi", "local":"ਪੰਜਾਬੀ", "1":"pa", "2":"pan", "2T":"pan", "2B":"pan", "3":"pan"},
     {"name":"Pāli", "local":"पाऴि", "1":"pi", "2":"pli", "2T":"pli", "2B":"pli", "3":"pli"},
-    {"name":"Persian", "local":"فارسی", "1":"fa", "2":"fas", "2T":"fas", "2B":"per", "3":"fas"},
+    {"name":"Persian", "local":"فارسی", "1":"fa", "2":"fas", "2T":"fas", "2B":"per", "3":"fas", "alias": ["Farsi"]},
     {"name":"Polish", "local":"język polski", "1":"pl", "2":"pol", "2T":"pol", "2B":"pol", "3":"pol"},
     {"name":"Pashto", "local":"پښتو", "1":"ps", "2":"pus", "2T":"pus", "2B":"pus", "3":"pus"},
     {"name":"Portuguese", "local":"português", "1":"pt", "2":"por", "2T":"por", "2B":"por", "3":"por"},

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var langs = {
     has:   hasLanguage,
     codes: getCodes,
     names: getNames,
-    where: findBy
+    where: findBy,
+    like:  like
 };
 
 module.exports = langs;
@@ -59,4 +60,21 @@ function forAll(arr, fn) {
 function isValidType(type) {
     var types = [1, 2, 3, '1', '2', '2B', '2T', '3'];
     return -1 !== types.indexOf(type);
+}
+
+// like :: String -> String
+function like(name, ignoreCase) {
+    for (var i = 0; i < data.length; i++) {
+        var lookup = data[i].alias || [];
+        lookup.push(data[i].name);
+        lookup.push(data[i].local);
+        if (ignoreCase) {
+            lookup = lookup.map(function (variant) {
+                return variant.toLowerCase();
+            });
+        }
+        if (lookup.indexOf(name) !== -1) {
+            return data[i];
+        }
+    }
 }


### PR DESCRIPTION
Hi,

The purpose of this pull request is to enable a "lazy" match on language names.

For instance, some language names in `data.js` contain characters beyond Basic Latin ASCII range (e.g. _Pāli_, _Norwegian Bokmål_). This could be fixed by cleaning data according to [official ISO standard](http://www.loc.gov/standards/iso639-2/php/English_list.php), but it wouldn't solve another problem: language names may have synonyms or transliteration variants (e.g. _Persian = Farsi_, _Pashto = Pushto_).

My idea is to add aliases for these languages in `data.js` and extend API to allow searching by these aliases:

```
// data.js:127
// {"name":"Persian", "alias": ["Farsi"], "local":"فارسی", "1":"fa", "2":"fas", "2T":"fas", "2B":"per", "3":"fas"},

langs.where('name', 'Persian') // ->  {'name': 'Persian', ...}
langs.where('name', 'Farsi') // -> undefined

langs.like('Persian') // -> {'name': 'Persian', ...}
langs.like('Farsi') // -> {'name': 'Persian', ...}
langs.like('persian', 'ignoreCase') // -> {'name': 'Persian', ...}
`