### PR TITLE
Fix Alpha2 ISO code for Divehi language

### DIFF
--- a/data.js
+++ b/data.js
@@ -36,7 +36,7 @@ module.exports = [
     {"name":"Croatian", "local":"hrvatski jezik", "1":"hr", "2":"hrv", "2T":"hrv", "2B":"hrv", "3":"hrv"},
     {"name":"Czech", "local":"čeština", "1":"cs", "2":"ces", "2T":"ces", "2B":"cze", "3":"ces"},
     {"name":"Danish", "local":"dansk", "1":"da", "2":"dan", "2T":"dan", "2B":"dan", "3":"dan"},
-    {"name":"Divehi", "local":"Divehi", "1":"iv", "2":"div", "2T":"div", "2B":"div", "3":"div"},
+    {"name":"Divehi", "local":"Divehi", "1":"dv", "2":"div", "2T":"div", "2B":"div", "3":"div"},
     {"name":"Dutch", "local":"Nederlands", "1":"nl", "2":"nld", "2T":"nld", "2B":"dut", "3":"nld"},
     {"name":"Dzongkha", "local":"རྫོང་ཁ", "1":"dz", "2":"dzo", "2T":"dzo", "2B":"dzo", "3":"dzo"},
     {"name":"English", "local":"English", "1":"en", "2":"eng", "2T":"eng", "2B":"eng", "3":"eng"},


### PR DESCRIPTION
Official ISO-639 Alpha 2 code for Divehi language is "dv" instead of "iv".
Reference from the ISO-639-2 Registration Authority: https://www.loc.gov/standards/iso639-2/ISO-639-2_8859-1.txt